### PR TITLE
Allow to Configure Docker Image Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Update this file with your preferences.
 CONTAINER_NAME=my-gitlab-container
 
 #
+# Tag of gitlab/gitlab-ce image to use.
+#
+GITLAB_IMAGE_TAG=latest
+
+#
 # Path where your Gitlab files will be located
 #
 GITLAB_DATA_PATH=/data/gitlab/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   gitlab-letsencrypt:
-    image: 'gitlab/gitlab-ce:latest'
+    image: gitlab/gitlab-ce:${GITLAB_IMAGE_TAG}
     container_name: ${CONTAINER_NAME}
     restart: always
     hostname: ${MAIN_DOMAIN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3"
 
 services:
   gitlab-letsencrypt:


### PR DESCRIPTION
According to the [Update Recommendations](https://docs.gitlab.com/ee/policy/maintenance.html#upgrade-recommendations) it should be possible to specify the tag to use. Otherwise a

```shell
docker-compose down
docker-compuse pull
docker-compuse up
```

might break all - which happened to me.